### PR TITLE
Add tryUpdate for update without RLS context

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ app.get('/', async function (req, res) {
     * [.set(key, value)](#module_node-rls.set) ⇒ <code>undefined</code>
     * [.delete(key)](#module_node-rls.delete) ⇒ <code>undefined</code>
     * [.update(obj)](#module_node-rls.update) ⇒ <code>undefined</code>
+    * [.tryUpdate(obj)](#module_node-rls.tryUpdate) ⇒ <code>boolean</code>
     * [.incr(key, count)](#module_node-rls.incr) ⇒ <code>Number</code>
     * [.decr(key, count)](#module_node-rls.decr) ⇒ <code>Number</code>
 
@@ -200,6 +201,25 @@ Update storage from a map
 // Update storage with all values from object
 const obj = {foo: 'bar', someKey: 'someValue'}
 await update(obj)
+console.log(await get('foo'))  // Prints bar
+```
+<a name="module_node-rls.tryUpdate"></a>
+
+### node-rls.tryUpdate(obj) ⇒ <code>boolean</code>
+Try to update storage from a map, fails silently
+
+**Kind**: static method of [<code>node-rls</code>](#module_node-rls)  
+**Returns**: <code>boolean</code> - Returns `true` on success, `false` otherwise  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| obj | <code>Object</code> | KV mapping object |
+
+**Example**  
+```js
+// Update storage with all values from object
+const obj = {foo: 'bar', someKey: 'someValue'}
+await tryUpdate(obj)
 console.log(await get('foo'))  // Prints bar
 ```
 <a name="module_node-rls.incr"></a>

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function withLock (callback) {
 async function tryLock (callback) {
   const meta = getMeta()
   if (meta === undefined) {
-    return
+    return false
   }
 
   return meta.lock.acquire('key', callback)
@@ -202,7 +202,7 @@ exports.update = async function (obj) {
  *
  * @async
  * @param {Object} obj - KV mapping object
- * @returns {undefined} No return value
+ * @returns {boolean} Returns `true` on success, `false` otherwise
  * @example
  * // Update storage with all values from object
  * const obj = {foo: 'bar', someKey: 'someValue'}
@@ -215,6 +215,7 @@ exports.tryUpdate = async function (obj) {
   return tryLock(async () => {
     const kv = Object.assign({}, meta.kv)
     meta.kv = Object.assign(kv, obj)
+    return true
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,15 @@ async function withLock (callback) {
   return meta.lock.acquire('key', callback)
 }
 
+async function tryLock (callback) {
+  const meta = getMeta()
+  if (meta === undefined) {
+    return
+  }
+
+  return meta.lock.acquire('key', callback)
+}
+
 async function incrDecrNumber (key, count, valueCb) {
   if (count === undefined) {
     count = 1
@@ -183,6 +192,27 @@ exports.update = async function (obj) {
   const meta = getMeta()
 
   return withLock(async () => {
+    const kv = Object.assign({}, meta.kv)
+    meta.kv = Object.assign(kv, obj)
+  })
+}
+
+/**
+ * Try to update storage from a map, fails silently
+ *
+ * @async
+ * @param {Object} obj - KV mapping object
+ * @returns {undefined} No return value
+ * @example
+ * // Update storage with all values from object
+ * const obj = {foo: 'bar', someKey: 'someValue'}
+ * await tryUpdate(obj)
+ * console.log(await get('foo'))  // Prints bar
+ */
+exports.tryUpdate = async function (obj) {
+  const meta = getMeta()
+
+  return tryLock(async () => {
     const kv = Object.assign({}, meta.kv)
     meta.kv = Object.assign(kv, obj)
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rls",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Request local storage for nodejs",
   "main": "index.js",
   "scripts": {

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -68,6 +68,7 @@ packages:
     dev: true
     engines:
       node: '>=6.0.0'
+    hasBin: true
     resolution:
       integrity: sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=
   /@babel/template/7.0.0-beta.49:
@@ -121,12 +122,14 @@ packages:
     dev: true
     engines:
       node: '>=0.4.0'
+    hasBin: true
     resolution:
       integrity: sha1-ReN/s56No/JbruP/U2niu18iAXo=
   /acorn/5.6.2:
     dev: true
     engines:
       node: '>=0.4.0'
+    hasBin: true
     resolution:
       integrity: sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==
   /ajv-keywords/2.1.1/ajv@5.5.2:
@@ -308,6 +311,7 @@ packages:
     dev: true
     engines:
       node: '>=4.2.0'
+    hasBin: true
     resolution:
       integrity: sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==
   /balanced-match/1.0.0:
@@ -1083,6 +1087,7 @@ packages:
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
       integrity: sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==
   /eslint/4.19.1:
@@ -1128,6 +1133,7 @@ packages:
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
       integrity: sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==
   /espree/3.5.4:
@@ -1143,6 +1149,7 @@ packages:
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
       integrity: sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==
   /esquery/1.0.1:
@@ -1441,6 +1448,7 @@ packages:
     dev: true
     engines:
       node: '>=0.4.7'
+    hasBin: true
     optionalDependencies:
       uglify-js: 2.8.29
     resolution:
@@ -1485,6 +1493,7 @@ packages:
       integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   /he/1.1.1:
     dev: true
+    hasBin: true
     resolution:
       integrity: sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
   /hosted-git-info/2.6.0:
@@ -1706,6 +1715,7 @@ packages:
       argparse: 1.0.10
       esprima: 4.0.0
     dev: true
+    hasBin: true
     resolution:
       integrity: sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
   /js2xmlparser/3.0.0:
@@ -1755,6 +1765,7 @@ packages:
     dev: true
     engines:
       node: '>=4.0.0'
+    hasBin: true
     resolution:
       integrity: sha512-LHJRoLoLyDdxNcColgkLoB/rFG5iRP+PNJjMILI0x+95IdEAtyjSt0wJ6ZlKxRpkhBYtQXTQQ119hMqPIUZzTQ==
   /jsdoc/3.5.5:
@@ -1774,12 +1785,14 @@ packages:
     dev: true
     engines:
       node: '>=4.2.0'
+    hasBin: true
     resolution:
       integrity: sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==
   /jsesc/2.5.1:
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
       integrity: sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=
   /json-parse-better-errors/1.0.2:
@@ -1895,6 +1908,7 @@ packages:
     dependencies:
       js-tokens: 3.0.2
     dev: true
+    hasBin: true
     resolution:
       integrity: sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=
   /lru-cache/4.1.3:
@@ -1908,6 +1922,7 @@ packages:
     dev: true
     engines:
       node: '>=0.10.0'
+    hasBin: true
     resolution:
       integrity: sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
   /media-typer/0.3.0:
@@ -1942,12 +1957,14 @@ packages:
       integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
   /mime/1.4.1:
     dev: true
+    hasBin: true
     resolution:
       integrity: sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
   /mime/1.6.0:
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
       integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
   /mimic-fn/1.2.0:
@@ -1978,6 +1995,7 @@ packages:
     dependencies:
       minimist: 0.0.8
     dev: true
+    hasBin: true
     resolution:
       integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   /mkdirp2/1.0.4:
@@ -2000,6 +2018,7 @@ packages:
     dev: true
     engines:
       node: '>= 4.0.0'
+    hasBin: true
     resolution:
       integrity: sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==
   /ms/2.0.0:
@@ -2071,6 +2090,7 @@ packages:
     dependencies:
       istanbul-lib-instrument: 2.1.0
     dev: true
+    hasBin: true
     resolution:
       integrity: sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=
   /object-assign/4.1.1:
@@ -2486,6 +2506,7 @@ packages:
     dependencies:
       glob: 7.1.2
     dev: true
+    hasBin: true
     resolution:
       integrity: sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   /run-async/2.3.0:
@@ -2523,6 +2544,7 @@ packages:
     resolution:
       integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
   /semver/5.5.0:
+    hasBin: true
     resolution:
       integrity: sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
   /send/0.16.2:
@@ -2675,6 +2697,7 @@ packages:
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
       integrity: sha512-nu0jAcHiSc8H+gJCXeiziMVZNDYi8MuqrYJKxTgjP4xKXZMKm311boqQIzDrYI/ktosltxt2CbDjYQs9ANC8IA==
   /statuses/1.4.0:
@@ -2914,6 +2937,7 @@ packages:
     dev: true
     engines:
       node: '>=0.8.0'
+    hasBin: true
     optional: true
     optionalDependencies:
       uglify-to-browserify: 1.0.2
@@ -2960,6 +2984,7 @@ packages:
       integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
   /uuid/3.2.1:
     dev: true
+    hasBin: true
     resolution:
       integrity: sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
   /validate-npm-package-license/3.0.3:
@@ -2995,6 +3020,7 @@ packages:
     dependencies:
       isexe: 2.0.0
     dev: true
+    hasBin: true
     resolution:
       integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   /window-size/0.1.0:
@@ -3067,7 +3093,7 @@ packages:
     resolution:
       integrity: sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=
 registry: 'https://registry.npmjs.org/'
-shrinkwrapMinorVersion: 6
+shrinkwrapMinorVersion: 8
 shrinkwrapVersion: 3
 specifiers:
   async-lock: ^1.1.2

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,40 @@ describe('Test getters/setters', () => {
     expect(await RLS.get('baz')).equal('foo')
   }))
 
+  it('Can update fails with NotInitializedError', async () => {
+    const obj = {
+      'foo': 'bar',
+      'baz': 'foo'
+    }
+
+    try {
+      await RLS.update(obj)
+      throw new Error('update should throw')
+    } catch (err) {
+      expect(err).instanceOf(RLS.NotInitializedError)
+    }
+  })
+
+  it('Can tryUpdate', async () => RLS.run(async () => {
+    const obj = {
+      'foo': 'foo',
+      'baz': 'baz'
+    }
+
+    await RLS.tryUpdate(obj)
+    expect(await RLS.get('foo')).equal('foo')
+    expect(await RLS.get('baz')).equal('baz')
+  }))
+
+  it('tryUpdate fails silently', async () => {
+    const obj = {
+      'foo': 'foo',
+      'baz': 'baz'
+    }
+
+    await RLS.tryUpdate(obj)
+  })
+
   it('Can delete', async () => RLS.run(async () => {
     await RLS.set('foo', 'bar')
     await RLS.delete('foo')

--- a/test/test.js
+++ b/test/test.js
@@ -49,7 +49,7 @@ describe('Test getters/setters', () => {
       'baz': 'baz'
     }
 
-    await RLS.tryUpdate(obj)
+    expect(await RLS.tryUpdate(obj)).equal(true)
     expect(await RLS.get('foo')).equal('foo')
     expect(await RLS.get('baz')).equal('baz')
   }))
@@ -60,7 +60,7 @@ describe('Test getters/setters', () => {
       'baz': 'baz'
     }
 
-    await RLS.tryUpdate(obj)
+    expect(await RLS.tryUpdate(obj)).equal(false)
   })
 
   it('Can delete', async () => RLS.run(async () => {


### PR DESCRIPTION
Some code paths have no RLS context initialized and `update` would throw. `tryUpdate` will return `false` instead of throw an exception.